### PR TITLE
Fixes to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.2.1-SNAPSHOT</version>
+            <version>4.3.0</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.11.2-R0.1-SNAPSHOT</version>
+            <groupId>org.bukkit</groupId>
+            <artifactId>craftbukkit</artifactId>
+            <version>1.12-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
@@ -43,7 +43,7 @@
     <build>
         <resources>
             <resource>
-                <directory>src\main\resources</directory>
+                <directory>${basedir}/src/main/resources</directory>
                 <excludes>
                     <!-- Prevent the test plugin from being included -->
                     <exclude>plugin.yml</exclude>
@@ -94,30 +94,6 @@
                         <exclude>TestPlugin.java</exclude>
                     </excludes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-                <executions>
-                    <execution>
-                        <id>install-external</id>
-                        <phase>clean</phase>
-                        <configuration>
-                            <file>${basedir}/run/${buildsoftware}.jar</file>
-                            <repositoryLayout>default</repositoryLayout>
-                            <groupId>org.spigotmc</groupId>
-                            <artifactId>spigot</artifactId>
-                            <version>1.11.2-R0.1-SNAPSHOT</version>
-                            <packaging>jar</packaging>
-                            <generatePom>true</generatePom>
-                            <sources>${basedir}/lib/${buildsoftware}-sources.jar</sources>
-                        </configuration>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Changes ProtocolLib-API to `4.3.0` (`4.2.1-SNAPSHOT` is no longer available on dmulloy's Maven repo)
- Removes requirement for external Spigot JAR. Just run `BuildTools.jar` once with `1.12` as the version, and this will then take CraftBukkit from your local maven repository.

Feel free to deny this PR if you want, but a friend needed to use your API and he couldn't due to the `4.2.1-SNAPSHOT` version on ProtocolLib-API. I fixed that, but then it was requiring a local JAR file for building and I really prefer this much more.

I'm not sure if removing the system of using the local JAR will break anything else, but it shouldn't, although to be fair I didn't really read too much into how you were loading the JAR.