### PR TITLE
Prevent ConcurrentModificationEx. in disable()

### DIFF
--- a/src/main/java/com/bringholm/nametagchanger/NameTagChanger.java
+++ b/src/main/java/com/bringholm/nametagchanger/NameTagChanger.java
@@ -328,7 +328,10 @@ public class NameTagChanger {
      */
     public void disable() {
         Validate.isTrue(enabled, "NameTagChanger is already disabled");
-        for (UUID uuid : gameProfiles.keySet()) {
+        
+        // Prevent ConcurrentModificationException by wrapping keySet in a list
+        List<UUID> playerUuids = new ArrayList<UUID>(gameProfiles.keySet());
+        for (UUID uuid : playerUuids) {
             Player player = Bukkit.getPlayer(uuid);
             if (player == null) {
                 continue;

--- a/src/main/java/com/bringholm/nametagchanger/NameTagChanger.java
+++ b/src/main/java/com/bringholm/nametagchanger/NameTagChanger.java
@@ -328,10 +328,8 @@ public class NameTagChanger {
      */
     public void disable() {
         Validate.isTrue(enabled, "NameTagChanger is already disabled");
-        
         // Prevent ConcurrentModificationException by wrapping keySet in a list
-        List<UUID> playerUuids = new ArrayList<UUID>(gameProfiles.keySet());
-        for (UUID uuid : playerUuids) {
+        for (UUID uuid : new ArrayList<>(gameProfiles.keySet())) {
             Player player = Bukkit.getPlayer(uuid);
             if (player == null) {
                 continue;


### PR DESCRIPTION
ConcurrentModificationExceptions can occur when a HashMap is modified while being iterated through. By first wrapping the gameProfiles.keySet() in an ArrayList, the HashMap is not modified while iterating through it. I'm not sure if this is the perfect solution, but it should do the job just fine.